### PR TITLE
周回数の記録に対応する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "ts-node -r tsconfig-paths/register src/main.ts",
     "compile": "tsc -p .",
     "deploy-command": "ts-node -r tsconfig-paths/register src/deploy-command.ts",
-    "typeorm": "typeorm-ts-node-commonjs"
+    "typeorm:generate": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:generate -d src/datasource.ts",
+    "typeorm:up": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run -d src/datasource.ts",
+    "typeorm:down": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert -d src/datasource.ts"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clanbattlebot",
   "version": "1.0.0",
-  "description": "クラバト簡易凸管理用bot試作品",
+  "description": "プリコネクランバトル凸管理用bot",
   "main": "index.js",
   "scripts": {
     "test": "jest",

--- a/src/app/model/Declaration.ts
+++ b/src/app/model/Declaration.ts
@@ -11,6 +11,7 @@ import Report from "@/entity/Report";
 export async function regist(
   boss: Boss,
   discordUserId: string,
+  lap: number,
   attackCount: number
 ): Promise<User | Error> {
   const today = dayjs().format();
@@ -40,7 +41,7 @@ export async function regist(
     user.id!,
     event!.id!,
     boss.id ?? 0,
-    0,
+    lap,
     event.getClanBattleDay(),
     attackCount,
     false

--- a/src/commands/button/DeclarationFirst.ts
+++ b/src/commands/button/DeclarationFirst.ts
@@ -72,9 +72,31 @@ export async function execute(interaction: ButtonInteraction) {
     eventId: event.id,
     clanId: clan.id,
   });
+  let bossLap = 0;
+  if (lap != null) {
+    switch (boss.bossid) {
+      case 1:
+        bossLap = lap.boss1Lap ?? 1;
+        break;
+      case 2:
+        bossLap = lap.boss2Lap ?? 1;
+        break;
+      case 3:
+        bossLap = lap.boss3Lap ?? 1;
+        break;
+      case 4:
+        bossLap = lap.boss4Lap ?? 1;
+        break;
+      case 5:
+        bossLap = lap.boss5Lap ?? 1;
+        break;
+      default:
+        break;
+    }
+  }
 
   let content = "";
-  const user = await Declaration.regist(boss, interaction.user.id, 1);
+  const user = await Declaration.regist(boss, interaction.user.id, bossLap, 1);
   if (user instanceof Error) {
     content = user.message;
   } else {

--- a/src/commands/button/DeclarationFirstAsCarryOver.ts
+++ b/src/commands/button/DeclarationFirstAsCarryOver.ts
@@ -4,12 +4,15 @@ import {
   ButtonInteraction,
   Guild,
 } from "discord.js";
+import dayjs from "dayjs";
 
 import Declaration from "@/app/model/Declaration";
 import DataSource from "@/datasource";
 import Boss from "@/entity/Boss";
 import Clan from "@/entity/Clan";
 import DeclarationRepository from "@/entity/Declaration";
+import Lap from "@/entity/Lap";
+import Event from "@/entity/Event";
 
 import BossChannelMessage from "@/messages/BossChannelMessage";
 
@@ -54,6 +57,23 @@ export async function execute(interaction: ButtonInteraction) {
     throw new Error("ボス情報が取得できませんでした");
   }
 
+  const today = dayjs().format();
+  const event = await DataSource.getRepository(Event)
+    .createQueryBuilder("event")
+    .where("event.fromDate <= :today", { today })
+    .andWhere("event.toDate >= :today", { today })
+    .getOne();
+  if (event == null) {
+    throw new Error("クランバトル開催情報が取得できませんでした");
+  }
+
+  // 周回数取得
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    eventId: event.id,
+    clanId: clan.id,
+  });
+
   let content = "";
   const user = await Declaration.regist(boss, interaction.user.id, 1);
   if (user instanceof Error) {
@@ -77,6 +97,7 @@ export async function execute(interaction: ButtonInteraction) {
     interaction.channel,
     clan,
     boss,
+    lap,
     declarations
   );
   const deleteMessage = await channel.messages.fetch(

--- a/src/commands/button/DeclarationFirstAsCarryOver.ts
+++ b/src/commands/button/DeclarationFirstAsCarryOver.ts
@@ -73,9 +73,31 @@ export async function execute(interaction: ButtonInteraction) {
     eventId: event.id,
     clanId: clan.id,
   });
+  let bossLap = 0;
+  if (lap != null) {
+    switch (boss.bossid) {
+      case 1:
+        bossLap = lap.boss1Lap ?? 1;
+        break;
+      case 2:
+        bossLap = lap.boss2Lap ?? 1;
+        break;
+      case 3:
+        bossLap = lap.boss3Lap ?? 1;
+        break;
+      case 4:
+        bossLap = lap.boss4Lap ?? 1;
+        break;
+      case 5:
+        bossLap = lap.boss5Lap ?? 1;
+        break;
+      default:
+        break;
+    }
+  }
 
   let content = "";
-  const user = await Declaration.regist(boss, interaction.user.id, 1);
+  const user = await Declaration.regist(boss, interaction.user.id, bossLap, 1);
   if (user instanceof Error) {
     content = user.message;
   } else {

--- a/src/commands/button/DeclarationSecond.ts
+++ b/src/commands/button/DeclarationSecond.ts
@@ -4,11 +4,14 @@ import {
   ButtonInteraction,
   Guild,
 } from "discord.js";
+import dayjs from "dayjs";
 
 import Declaration from "@/app/model/Declaration";
 import DataSource from "@/datasource";
 import Boss from "@/entity/Boss";
 import Clan from "@/entity/Clan";
+import Lap from "@/entity/Lap";
+import Event from "@/entity/Event";
 import DeclarationRepository from "@/entity/Declaration";
 import BossChannelMessage from "@/messages/BossChannelMessage";
 
@@ -53,6 +56,23 @@ export async function execute(interaction: ButtonInteraction) {
     throw new Error("ボス情報が取得できませんでした");
   }
 
+  const today = dayjs().format();
+  const event = await DataSource.getRepository(Event)
+    .createQueryBuilder("event")
+    .where("event.fromDate <= :today", { today })
+    .andWhere("event.toDate >= :today", { today })
+    .getOne();
+  if (event == null) {
+    throw new Error("クランバトル開催情報が取得できませんでした");
+  }
+
+  // 周回数取得
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    eventId: event.id,
+    clanId: clan.id,
+  });
+
   let content = "";
   const user = await Declaration.regist(boss, interaction.user.id, 2);
   if (user instanceof Error) {
@@ -76,6 +96,7 @@ export async function execute(interaction: ButtonInteraction) {
     interaction.channel,
     clan,
     boss,
+    lap,
     declarations
   );
   const deleteMessage = await channel.messages.fetch(

--- a/src/commands/button/DeclarationSecond.ts
+++ b/src/commands/button/DeclarationSecond.ts
@@ -72,9 +72,31 @@ export async function execute(interaction: ButtonInteraction) {
     eventId: event.id,
     clanId: clan.id,
   });
+  let bossLap = 0;
+  if (lap != null) {
+    switch (boss.bossid) {
+      case 1:
+        bossLap = lap.boss1Lap ?? 1;
+        break;
+      case 2:
+        bossLap = lap.boss2Lap ?? 1;
+        break;
+      case 3:
+        bossLap = lap.boss3Lap ?? 1;
+        break;
+      case 4:
+        bossLap = lap.boss4Lap ?? 1;
+        break;
+      case 5:
+        bossLap = lap.boss5Lap ?? 1;
+        break;
+      default:
+        break;
+    }
+  }
 
   let content = "";
-  const user = await Declaration.regist(boss, interaction.user.id, 2);
+  const user = await Declaration.regist(boss, interaction.user.id, bossLap, 2);
   if (user instanceof Error) {
     content = user.message;
   } else {

--- a/src/commands/button/DeclarationSecondAsCarryOver.ts
+++ b/src/commands/button/DeclarationSecondAsCarryOver.ts
@@ -4,11 +4,14 @@ import {
   ButtonInteraction,
   Guild,
 } from "discord.js";
+import dayjs from "dayjs";
 
 import Declaration from "@/app/model/Declaration";
 import DataSource from "@/datasource";
 import Boss from "@/entity/Boss";
 import Clan from "@/entity/Clan";
+import Lap from "@/entity/Lap";
+import Event from "@/entity/Event";
 import DeclarationRepository from "@/entity/Declaration";
 import BossChannelMessage from "@/messages/BossChannelMessage";
 
@@ -52,7 +55,22 @@ export async function execute(interaction: ButtonInteraction) {
   if (boss == null) {
     throw new Error("ボス情報が取得できませんでした");
   }
+  const today = dayjs().format();
+  const event = await DataSource.getRepository(Event)
+    .createQueryBuilder("event")
+    .where("event.fromDate <= :today", { today })
+    .andWhere("event.toDate >= :today", { today })
+    .getOne();
+  if (event == null) {
+    throw new Error("クランバトル開催情報が取得できませんでした");
+  }
 
+  // 周回数取得
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    eventId: event.id,
+    clanId: clan.id,
+  });
   let content = "";
   const user = await Declaration.regist(boss, interaction.user.id, 2);
   if (user instanceof Error) {
@@ -76,6 +94,7 @@ export async function execute(interaction: ButtonInteraction) {
     interaction.channel,
     clan,
     boss,
+    lap,
     declarations
   );
   const deleteMessage = await channel.messages.fetch(

--- a/src/commands/button/DeclarationSecondAsCarryOver.ts
+++ b/src/commands/button/DeclarationSecondAsCarryOver.ts
@@ -71,8 +71,31 @@ export async function execute(interaction: ButtonInteraction) {
     eventId: event.id,
     clanId: clan.id,
   });
+  let bossLap = 0;
+  if (lap != null) {
+    switch (boss.bossid) {
+      case 1:
+        bossLap = lap.boss1Lap ?? 1;
+        break;
+      case 2:
+        bossLap = lap.boss2Lap ?? 1;
+        break;
+      case 3:
+        bossLap = lap.boss3Lap ?? 1;
+        break;
+      case 4:
+        bossLap = lap.boss4Lap ?? 1;
+        break;
+      case 5:
+        bossLap = lap.boss5Lap ?? 1;
+        break;
+      default:
+        break;
+    }
+  }
+
   let content = "";
-  const user = await Declaration.regist(boss, interaction.user.id, 2);
+  const user = await Declaration.regist(boss, interaction.user.id, bossLap, 2);
   if (user instanceof Error) {
     content = user.message;
   } else {

--- a/src/commands/button/DeclarationThird.ts
+++ b/src/commands/button/DeclarationThird.ts
@@ -71,9 +71,31 @@ export async function execute(interaction: ButtonInteraction) {
     eventId: event.id,
     clanId: clan.id,
   });
+  let bossLap = 0;
+  if (lap != null) {
+    switch (boss.bossid) {
+      case 1:
+        bossLap = lap.boss1Lap ?? 1;
+        break;
+      case 2:
+        bossLap = lap.boss2Lap ?? 1;
+        break;
+      case 3:
+        bossLap = lap.boss3Lap ?? 1;
+        break;
+      case 4:
+        bossLap = lap.boss4Lap ?? 1;
+        break;
+      case 5:
+        bossLap = lap.boss5Lap ?? 1;
+        break;
+      default:
+        break;
+    }
+  }
 
   let content = "";
-  const user = await Declaration.regist(boss, interaction.user.id, 3);
+  const user = await Declaration.regist(boss, interaction.user.id, bossLap, 3);
   if (user instanceof Error) {
     content = user.message;
   } else {

--- a/src/commands/button/DeclarationThird.ts
+++ b/src/commands/button/DeclarationThird.ts
@@ -4,11 +4,14 @@ import {
   ButtonInteraction,
   Guild,
 } from "discord.js";
+import dayjs from "dayjs";
 
 import Declaration from "@/app/model/Declaration";
 import DataSource from "@/datasource";
 import Boss from "@/entity/Boss";
 import Clan from "@/entity/Clan";
+import Lap from "@/entity/Lap";
+import Event from "@/entity/Event";
 import DeclarationRepository from "@/entity/Declaration";
 import BossChannelMessage from "@/messages/BossChannelMessage";
 
@@ -52,6 +55,22 @@ export async function execute(interaction: ButtonInteraction) {
   if (boss == null) {
     throw new Error("ボス情報が取得できませんでした");
   }
+  const today = dayjs().format();
+  const event = await DataSource.getRepository(Event)
+    .createQueryBuilder("event")
+    .where("event.fromDate <= :today", { today })
+    .andWhere("event.toDate >= :today", { today })
+    .getOne();
+  if (event == null) {
+    throw new Error("クランバトル開催情報が取得できませんでした");
+  }
+
+  // 周回数取得
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    eventId: event.id,
+    clanId: clan.id,
+  });
 
   let content = "";
   const user = await Declaration.regist(boss, interaction.user.id, 3);
@@ -76,6 +95,7 @@ export async function execute(interaction: ButtonInteraction) {
     interaction.channel,
     clan,
     boss,
+    lap,
     declarations
   );
   const deleteMessage = await channel.messages.fetch(

--- a/src/commands/button/DeclarationThirdAsCarryOver.ts
+++ b/src/commands/button/DeclarationThirdAsCarryOver.ts
@@ -71,9 +71,31 @@ export async function execute(interaction: ButtonInteraction) {
     eventId: event.id,
     clanId: clan.id,
   });
+  let bossLap = 0;
+  if (lap != null) {
+    switch (boss.bossid) {
+      case 1:
+        bossLap = lap.boss1Lap ?? 1;
+        break;
+      case 2:
+        bossLap = lap.boss2Lap ?? 1;
+        break;
+      case 3:
+        bossLap = lap.boss3Lap ?? 1;
+        break;
+      case 4:
+        bossLap = lap.boss4Lap ?? 1;
+        break;
+      case 5:
+        bossLap = lap.boss5Lap ?? 1;
+        break;
+      default:
+        break;
+    }
+  }
 
   let content = "";
-  const user = await Declaration.regist(boss, interaction.user.id, 3);
+  const user = await Declaration.regist(boss, interaction.user.id, bossLap, 3);
   if (user instanceof Error) {
     content = user.message;
   } else {

--- a/src/commands/button/DeclarationThirdAsCarryOver.ts
+++ b/src/commands/button/DeclarationThirdAsCarryOver.ts
@@ -4,11 +4,14 @@ import {
   ButtonInteraction,
   Guild,
 } from "discord.js";
+import dayjs from "dayjs";
 
 import Declaration from "@/app/model/Declaration";
 import DataSource from "@/datasource";
 import Boss from "@/entity/Boss";
 import Clan from "@/entity/Clan";
+import Lap from "@/entity/Lap";
+import Event from "@/entity/Event";
 import DeclarationRepository from "@/entity/Declaration";
 import BossChannelMessage from "@/messages/BossChannelMessage";
 
@@ -52,6 +55,22 @@ export async function execute(interaction: ButtonInteraction) {
   if (boss == null) {
     throw new Error("ボス情報が取得できませんでした");
   }
+  const today = dayjs().format();
+  const event = await DataSource.getRepository(Event)
+    .createQueryBuilder("event")
+    .where("event.fromDate <= :today", { today })
+    .andWhere("event.toDate >= :today", { today })
+    .getOne();
+  if (event == null) {
+    throw new Error("クランバトル開催情報が取得できませんでした");
+  }
+
+  // 周回数取得
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    eventId: event.id,
+    clanId: clan.id,
+  });
 
   let content = "";
   const user = await Declaration.regist(boss, interaction.user.id, 3);
@@ -76,6 +95,7 @@ export async function execute(interaction: ButtonInteraction) {
     interaction.channel,
     clan,
     boss,
+    lap,
     declarations
   );
   const deleteMessage = await channel.messages.fetch(

--- a/src/commands/button/declaration_start.ts
+++ b/src/commands/button/declaration_start.ts
@@ -75,7 +75,7 @@ export async function execute(interaction: ButtonInteraction) {
     .andWhere("user.clanId = :clanId", { clanId: clan.id })
     .getOne();
   if (clanUser == null) {
-    return new Error("あなたはこのクランに所属していないよ");
+    throw new Error("あなたはこのクランに所属していないよ");
   }
 
   const interactionChannelId = interaction.channelId;
@@ -86,7 +86,7 @@ export async function execute(interaction: ButtonInteraction) {
     })
     .getOne();
   if (boss == null) {
-    return new Error("ボス情報を取得できません");
+    throw new Error("ボス情報を取得できません");
   }
 
   const lapRepository = DataSource.getRepository(Lap);
@@ -95,10 +95,10 @@ export async function execute(interaction: ButtonInteraction) {
     clanId: clan.id,
   });
   if (lap == null) {
-    return new Error("周回数情報を取得できません");
+    throw new Error("周回数情報を取得できません");
   }
   if (!lap.isAttackPossible(boss.bossid)) {
-    return new Error("このボスは凸できません");
+    throw new Error("このボスは凸できません");
   }
 
   let bossLap = 0;

--- a/src/commands/button/declaration_start.ts
+++ b/src/commands/button/declaration_start.ts
@@ -97,6 +97,9 @@ export async function execute(interaction: ButtonInteraction) {
   if (lap == null) {
     return new Error("周回数情報を取得できません");
   }
+  if (!lap.isAttackPossible(boss.bossid)) {
+    return new Error("このボスは凸できません");
+  }
 
   let bossLap = 0;
 

--- a/src/commands/button/declaration_start.ts
+++ b/src/commands/button/declaration_start.ts
@@ -45,7 +45,7 @@ export async function execute(interaction: ButtonInteraction) {
   const interactionUserId = interaction.user.id;
   const clanUser = await DataSource.getRepository(User)
     .createQueryBuilder("user")
-    .where("user.discordUserId = :userId", { interactionUserId })
+    .where("user.discordUserId = :userId", { userId: interactionUserId })
     .getOne();
   if (clanUser == null) {
     return new Error("あなたはこのクランに所属していないよ");
@@ -54,7 +54,9 @@ export async function execute(interaction: ButtonInteraction) {
   const interactionChannelId = interaction.channelId;
   const boss = await DataSource.getRepository(Boss)
     .createQueryBuilder("boss")
-    .where("boss.discordChannelId = :channelId", { interactionChannelId })
+    .where("boss.discordChannelId = :channelId", {
+      channelId: interactionChannelId,
+    })
     .getOne();
   if (boss == null) {
     return new Error("ボス情報を取得できません");
@@ -62,7 +64,7 @@ export async function execute(interaction: ButtonInteraction) {
 
   const todayReports = clanUser.getTodayReports(event, dayCount);
 
-  // なし:- 持ち越しなし:x　持ち越しあり:y　持ち越し済み:z
+  // なし:- 持ち越しなし:x 持ち越しあり:y 持ち越し済み:z
 
   if (todayReports == null) {
     // ---

--- a/src/commands/button/declaration_start.ts
+++ b/src/commands/button/declaration_start.ts
@@ -3,6 +3,7 @@ import {
   ButtonStyle,
   ButtonInteraction,
   ActionRowBuilder,
+  Guild,
 } from "discord.js";
 import dayjs from "dayjs";
 
@@ -17,6 +18,8 @@ import buttonAttackThird from "@/commands/button/DeclarationThird";
 import buttonAttackFirstAsCarryOver from "@/commands/button/DeclarationFirstAsCarryOver";
 import buttonAttackSecondAsCarryOver from "@/commands/button/DeclarationSecondAsCarryOver";
 import buttonAttackThirdAsCarryOver from "@/commands/button/DeclarationThirdAsCarryOver";
+import Lap from "@/entity/Lap";
+import Clan from "@/entity/Clan";
 
 export const customId = "declaration_start";
 export const data = new ButtonBuilder()
@@ -42,10 +45,34 @@ export async function execute(interaction: ButtonInteraction) {
   }
   const dayCount = event.getClanBattleDay();
 
+  let guild: Guild;
+  if (interaction.guild != null) {
+    guild = interaction.guild;
+  } else {
+    throw new Error("interaction.guild is null");
+  }
+  const channel = guild.channels.cache.find(
+    (channel) => channel.id === interaction.channel?.id
+  );
+  if (channel == null) {
+    throw new Error("channel is null");
+  }
+  if (channel.parentId == null) {
+    throw new Error("channel.parentId is null");
+  }
+  // クラン取得
+  const clan = await DataSource.getRepository(Clan).findOneBy({
+    discordCategoryId: channel.parentId,
+  });
+  if (clan == null) {
+    throw new Error("クラン情報が取得できませんでした");
+  }
+
   const interactionUserId = interaction.user.id;
   const clanUser = await DataSource.getRepository(User)
     .createQueryBuilder("user")
     .where("user.discordUserId = :userId", { userId: interactionUserId })
+    .andWhere("user.clanId = :clanId", { clanId: clan.id })
     .getOne();
   if (clanUser == null) {
     return new Error("あなたはこのクランに所属していないよ");
@@ -62,6 +89,36 @@ export async function execute(interaction: ButtonInteraction) {
     return new Error("ボス情報を取得できません");
   }
 
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    eventId: event.id,
+    clanId: clan.id,
+  });
+  if (lap == null) {
+    return new Error("周回数情報を取得できません");
+  }
+
+  let bossLap = 0;
+
+  switch (boss.bossid) {
+    case 1:
+      bossLap = lap.boss1Lap ?? 1;
+      break;
+    case 2:
+      bossLap = lap.boss2Lap ?? 1;
+      break;
+    case 3:
+      bossLap = lap.boss3Lap ?? 1;
+      break;
+    case 4:
+      bossLap = lap.boss4Lap ?? 1;
+      break;
+    case 5:
+      bossLap = lap.boss5Lap ?? 1;
+      break;
+    default:
+      break;
+  }
   const todayReports = clanUser.getTodayReports(event, dayCount);
 
   // なし:- 持ち越しなし:x 持ち越しあり:y 持ち越し済み:z
@@ -72,7 +129,9 @@ export async function execute(interaction: ButtonInteraction) {
       content:
         "【宣言】" +
         clanUser.name +
-        "さんの x周目 " +
+        "さんの " +
+        bossLap +
+        "周目 " +
         boss.bossid +
         "ボス 宣言だよ。",
       ephemeral: true,
@@ -107,7 +166,9 @@ export async function execute(interaction: ButtonInteraction) {
         content:
           "【宣言】" +
           clanUser.name +
-          "さんの x周目 " +
+          "さんの " +
+          bossLap +
+          "周目 " +
           boss.bossid +
           "ボス 宣言だよ。",
         ephemeral: true,
@@ -124,7 +185,9 @@ export async function execute(interaction: ButtonInteraction) {
         content:
           "【宣言】" +
           clanUser.name +
-          "さんの x周目 " +
+          "さんの " +
+          bossLap +
+          "周目 " +
           boss.bossid +
           "ボス 宣言だよ。",
         ephemeral: true,
@@ -151,7 +214,9 @@ export async function execute(interaction: ButtonInteraction) {
           content:
             "【宣言】" +
             clanUser.name +
-            "さんの x周目 " +
+            "さんの " +
+            bossLap +
+            "周目 " +
             boss.bossid +
             "ボス 宣言だよ。",
           ephemeral: true,
@@ -168,7 +233,9 @@ export async function execute(interaction: ButtonInteraction) {
           content:
             "【宣言】" +
             clanUser.name +
-            "さんの x周目 " +
+            "さんの " +
+            bossLap +
+            "周目 " +
             boss.bossid +
             "ボス 宣言だよ。",
           ephemeral: true,
@@ -188,7 +255,9 @@ export async function execute(interaction: ButtonInteraction) {
           content:
             "【宣言】" +
             clanUser.name +
-            "さんの x周目 " +
+            "さんの " +
+            bossLap +
+            "周目 " +
             boss.bossid +
             "ボス 宣言だよ。",
           ephemeral: true,
@@ -206,7 +275,9 @@ export async function execute(interaction: ButtonInteraction) {
           content:
             "【宣言】" +
             clanUser.name +
-            "さんの x周目 " +
+            "さんの " +
+            bossLap +
+            "周目 " +
             boss.bossid +
             "ボス 宣言だよ。",
           ephemeral: true,

--- a/src/commands/button/report_defeat.ts
+++ b/src/commands/button/report_defeat.ts
@@ -15,6 +15,7 @@ import Clan from "@/entity/Clan";
 import Event from "@/entity/Event";
 import Declaration from "@/entity/Declaration";
 import BossChannelMessage from "@/messages/BossChannelMessage";
+import Lap from "@/entity/Lap";
 
 export const customId = "report_defeat";
 export const data = new ButtonBuilder()
@@ -51,6 +52,7 @@ export async function execute(interaction: ButtonInteraction) {
   if (channel.parentId == null) {
     throw new Error("channel.parentId is null");
   }
+  // クラン取得
   const clan = await DataSource.getRepository(Clan).findOneBy({
     discordCategoryId: channel.parentId,
   });
@@ -74,6 +76,7 @@ export async function execute(interaction: ButtonInteraction) {
   if (user == null) {
     throw new Error("ユーザー情報が取得できませんでした");
   }
+  // 凸宣言取得
   const declarationRepository = DataSource.getRepository(Declaration);
   const declaration = await declarationRepository.findOneBy({
     isFinished: false,
@@ -86,7 +89,53 @@ export async function execute(interaction: ButtonInteraction) {
   if (declaration.id == null) {
     throw new Error("declaration.id is null");
   }
+  // 対象凸を完了状態にする
   await declarationRepository.update(declaration.id, { isFinished: true });
+
+  // 周回数更新
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    clanId: clan.id,
+    eventId: event.id,
+  });
+  if (lap == null) {
+    throw new Error("周回数情報が取得できませんでした");
+  }
+  switch (boss.bossid) {
+    case 1:
+      if (lap.boss1Lap == null) {
+        throw new Error("lap.boss1Lap is null");
+      }
+      lap.boss1Lap += 1;
+      break;
+    case 2:
+      if (lap.boss2Lap == null) {
+        throw new Error("lap.boss2Lap is null");
+      }
+      lap.boss2Lap += 1;
+      break;
+    case 3:
+      if (lap.boss3Lap == null) {
+        throw new Error("lap.boss3Lap is null");
+      }
+      lap.boss3Lap += 1;
+      break;
+    case 4:
+      if (lap.boss4Lap == null) {
+        throw new Error("lap.boss4Lap is null");
+      }
+      lap.boss4Lap += 1;
+      break;
+    case 5:
+      if (lap.boss5Lap == null) {
+        throw new Error("lap.boss5Lap is null");
+      }
+      lap.boss5Lap += 1;
+      break;
+    default:
+      break;
+  }
+  await lapRepository.save(lap);
 
   // 持ち越しが発生しているかチェック
   let isCarryOver = false;
@@ -115,6 +164,7 @@ export async function execute(interaction: ButtonInteraction) {
     isCarryOver
   );
   await DataSource.getRepository(Report).save(report);
+
   content = user.name + "が" + boss.bossid + "ボスを撃破しました";
 
   const declarations = await DataSource.getRepository(Declaration).find({

--- a/src/commands/button/report_defeat.ts
+++ b/src/commands/button/report_defeat.ts
@@ -180,6 +180,7 @@ export async function execute(interaction: ButtonInteraction) {
     interaction.channel,
     clan,
     boss,
+    lap,
     declarations
   );
   await interaction.reply({ content: content });

--- a/src/commands/button/report_defeat.ts
+++ b/src/commands/button/report_defeat.ts
@@ -98,6 +98,7 @@ export async function execute(interaction: ButtonInteraction) {
     clanId: clan.id,
     eventId: event.id,
   });
+  let bossLap = 0;
   if (lap == null) {
     throw new Error("周回数情報が取得できませんでした");
   }
@@ -107,30 +108,35 @@ export async function execute(interaction: ButtonInteraction) {
         throw new Error("lap.boss1Lap is null");
       }
       lap.boss1Lap += 1;
+      bossLap = lap.boss1Lap;
       break;
     case 2:
       if (lap.boss2Lap == null) {
         throw new Error("lap.boss2Lap is null");
       }
       lap.boss2Lap += 1;
+      bossLap = lap.boss2Lap;
       break;
     case 3:
       if (lap.boss3Lap == null) {
         throw new Error("lap.boss3Lap is null");
       }
       lap.boss3Lap += 1;
+      bossLap = lap.boss3Lap;
       break;
     case 4:
       if (lap.boss4Lap == null) {
         throw new Error("lap.boss4Lap is null");
       }
       lap.boss4Lap += 1;
+      bossLap = lap.boss4Lap;
       break;
     case 5:
       if (lap.boss5Lap == null) {
         throw new Error("lap.boss5Lap is null");
       }
       lap.boss5Lap += 1;
+      bossLap = lap.boss5Lap;
       break;
     default:
       break;
@@ -156,7 +162,7 @@ export async function execute(interaction: ButtonInteraction) {
     user.id!,
     event.id!,
     boss.bossid,
-    0,
+    bossLap,
     event.getClanBattleDay(),
     declaration.attackCount,
     0,

--- a/src/commands/button/report_shave.ts
+++ b/src/commands/button/report_shave.ts
@@ -13,6 +13,7 @@ import Report from "@/entity/Report";
 import Boss from "@/entity/Boss";
 import Clan from "@/entity/Clan";
 import Event from "@/entity/Event";
+import Lap from "@/entity/Lap";
 import Declaration from "@/entity/Declaration";
 import BossChannelMessage from "@/messages/BossChannelMessage";
 
@@ -55,6 +56,13 @@ export async function execute(interaction: ButtonInteraction) {
   if (boss == null) {
     throw new Error("ボス情報が取得できませんでした");
   }
+
+  // 周回数取得
+  const lapRepository = DataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    eventId: event.id,
+    clanId: clan.id,
+  });
   // ユーザー取得
   const userRepository = DataSource.getRepository(User);
   const user = await userRepository.findOneBy({
@@ -103,6 +111,7 @@ export async function execute(interaction: ButtonInteraction) {
     interaction.channel!,
     clan,
     boss,
+    lap,
     declarations
   );
   await interaction.reply({

--- a/src/commands/button/report_shave.ts
+++ b/src/commands/button/report_shave.ts
@@ -63,6 +63,29 @@ export async function execute(interaction: ButtonInteraction) {
     eventId: event.id,
     clanId: clan.id,
   });
+  if (lap == null) {
+    throw new Error("周回数が取得できませんでした");
+  }
+  let bossLap = 0;
+  switch (boss.bossid) {
+    case 1:
+      bossLap = lap.boss1Lap ?? 0;
+      break;
+    case 2:
+      bossLap = lap.boss2Lap ?? 0;
+      break;
+    case 3:
+      bossLap = lap.boss3Lap ?? 0;
+      break;
+    case 4:
+      bossLap = lap.boss4Lap ?? 0;
+      break;
+    case 5:
+      bossLap = lap.boss5Lap ?? 0;
+      break;
+    default:
+      break;
+  }
   // ユーザー取得
   const userRepository = DataSource.getRepository(User);
   const user = await userRepository.findOneBy({
@@ -88,7 +111,7 @@ export async function execute(interaction: ButtonInteraction) {
     user.id!,
     event!.id!,
     boss.bossid,
-    0,
+    bossLap,
     event.getClanBattleDay(),
     declaration.attackCount,
     0,

--- a/src/commands/slash/setup.ts
+++ b/src/commands/slash/setup.ts
@@ -131,7 +131,14 @@ async function createManagementChannel(
   });
 
   if (channel.isTextBased()) {
-    await management_message.sendMessage(channel, null, users, null, true);
+    await management_message.sendMessage(
+      channel,
+      null,
+      clan,
+      users,
+      null,
+      true
+    );
   }
 }
 
@@ -164,6 +171,12 @@ async function createBossChannel(
 
   const declaration: Declaration[] = [];
   if (channel?.isTextBased()) {
-    await BossChannelMessage.sendMessage(channel, clan, boss, declaration);
+    await BossChannelMessage.sendMessage(
+      channel,
+      clan,
+      boss,
+      null,
+      declaration
+    );
   }
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,12 +1,6 @@
 import "reflect-metadata";
 import { DataSource } from "typeorm";
 import dotenv from "dotenv";
-import Boss from "@/entity/Boss";
-import Clan from "@/entity/Clan";
-import Declaration from "@/entity/Declaration";
-import Event from "@/entity/Event";
-import Report from "@/entity/Report";
-import User from "@/entity/User";
 
 dotenv.config();
 
@@ -19,7 +13,7 @@ const dataSource = new DataSource({
   database: process.env.DB_NAME ?? "",
   synchronize: false,
   logging: process.env.DB_LOGGING === "true" ? true : false,
-  entities: [Boss, Clan, Declaration, Event, Report, User],
+  entities: [`src/entity/*`],
   migrations: [`src/migration/*`],
 });
 

--- a/src/entity/Clan.ts
+++ b/src/entity/Clan.ts
@@ -19,16 +19,6 @@ export default class Clan {
   discordRoleId: string;
   @Column()
   discordCategoryId: string;
-  @Column({ default: 1 })
-  boss1Lap?: number;
-  @Column({ default: 1 })
-  boss2Lap?: number;
-  @Column({ default: 1 })
-  boss3Lap?: number;
-  @Column({ default: 1 })
-  boss4Lap?: number;
-  @Column({ default: 1 })
-  boss5Lap?: number;
   @CreateDateColumn()
   CreatedAt?: Date;
   @UpdateDateColumn()

--- a/src/entity/Lap.ts
+++ b/src/entity/Lap.ts
@@ -24,4 +24,62 @@ export default class Lap {
     this.clanId = clanId;
     this.eventId = eventId;
   }
+
+  isAttackPossible(bossId: number): boolean {
+    switch (bossId) {
+      case 1:
+        if (
+          this.boss1Lap! - this.boss2Lap! >= 2 ||
+          this.boss1Lap! - this.boss3Lap! >= 2 ||
+          this.boss1Lap! - this.boss4Lap! >= 2 ||
+          this.boss1Lap! - this.boss5Lap! >= 2
+        ) {
+          return false;
+        }
+        break;
+      case 2:
+        if (
+          this.boss2Lap! - this.boss1Lap! >= 2 ||
+          this.boss2Lap! - this.boss3Lap! >= 2 ||
+          this.boss2Lap! - this.boss4Lap! >= 2 ||
+          this.boss2Lap! - this.boss5Lap! >= 2
+        ) {
+          return false;
+        }
+        break;
+      case 3:
+        if (
+          this.boss3Lap! - this.boss1Lap! >= 2 ||
+          this.boss3Lap! - this.boss2Lap! >= 2 ||
+          this.boss3Lap! - this.boss4Lap! >= 2 ||
+          this.boss3Lap! - this.boss5Lap! >= 2
+        ) {
+          return false;
+        }
+        break;
+      case 4:
+        if (
+          this.boss4Lap! - this.boss1Lap! >= 2 ||
+          this.boss4Lap! - this.boss2Lap! >= 2 ||
+          this.boss4Lap! - this.boss3Lap! >= 2 ||
+          this.boss4Lap! - this.boss5Lap! >= 2
+        ) {
+          return false;
+        }
+        break;
+      case 5:
+        if (
+          this.boss5Lap! - this.boss1Lap! >= 2 ||
+          this.boss5Lap! - this.boss2Lap! >= 2 ||
+          this.boss5Lap! - this.boss3Lap! >= 2 ||
+          this.boss5Lap! - this.boss4Lap! >= 2
+        ) {
+          return false;
+        }
+        break;
+      default:
+        break;
+    }
+    return true;
+  }
 }

--- a/src/entity/Lap.ts
+++ b/src/entity/Lap.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+
+@Entity()
+// クランバトル周回数
+export default class Lap {
+  @PrimaryGeneratedColumn()
+  id?: number;
+  @Column()
+  clanId: number;
+  @Column()
+  eventId: number;
+  @Column({ default: 1 })
+  boss1Lap?: number;
+  @Column({ default: 1 })
+  boss2Lap?: number;
+  @Column({ default: 1 })
+  boss3Lap?: number;
+  @Column({ default: 1 })
+  boss4Lap?: number;
+  @Column({ default: 1 })
+  boss5Lap?: number;
+
+  constructor(clanId: number, eventId: number) {
+    this.clanId = clanId;
+    this.eventId = eventId;
+  }
+}

--- a/src/messages/BossChannelMessage.ts
+++ b/src/messages/BossChannelMessage.ts
@@ -12,11 +12,13 @@ import button_declaration_cancel from "@/commands/button/declaration_cancel";
 import Clan from "@/entity/Clan";
 import Boss from "@/entity/Boss";
 import Declaration from "@/entity/Declaration";
+import Lap from "@/entity/Lap";
 
 export async function sendMessage(
   channel: TextBasedChannel,
   clan: Clan,
   boss: Boss,
+  lap: Lap | null,
   declaration: Declaration[]
 ) {
   let declarationMember = "凸宣言者なし";
@@ -26,6 +28,29 @@ export async function sendMessage(
       declarationMember = declarationMember + "\n" + declaration.user.name;
     });
   }
+  let bossLap = 1;
+  if (lap != null) {
+    switch (boss.bossid) {
+      case 1:
+        bossLap = lap.boss1Lap ?? 1;
+        break;
+      case 2:
+        bossLap = lap.boss2Lap ?? 1;
+        break;
+      case 3:
+        bossLap = lap.boss3Lap ?? 1;
+        break;
+      case 4:
+        bossLap = lap.boss4Lap ?? 1;
+        break;
+      case 5:
+        bossLap = lap.boss5Lap ?? 1;
+        break;
+      default:
+        break;
+    }
+  }
+
   // コンポーネント定義
   const embed = new EmbedBuilder()
     .setTitle(boss.bossid + "ボス")
@@ -35,11 +60,10 @@ export async function sendMessage(
         name: "クラン名",
         value: clan.name,
       },
-      // TODO: 今後実装
-      // {
-      //   name: '周回数',
-      //   value: "1周目"
-      // },
+      {
+        name: "周回数",
+        value: bossLap + "周目",
+      },
       // TODO: 今後実装
       // {
       //   name: 'HP',

--- a/src/messages/ManagementChannelMessage.ts
+++ b/src/messages/ManagementChannelMessage.ts
@@ -17,15 +17,20 @@ import Event from "@/entity/Event";
 import Clan from "@/entity/Clan";
 import Report from "@/entity/Report";
 import Boss from "@/entity/Boss";
+import Lap from "@/entity/Lap";
 
 export async function sendMessage(
   channel: TextBasedChannel,
   message: Message | null,
   clan: Clan,
   users: User[],
-  event: Event,
+  event: Event | null,
   isInit: boolean
 ) {
+  if (event == null) {
+    throw new Error("event is null");
+  }
+
   let userStatus = "メンバー(" + users.length + ")\n";
   users.forEach((user) => {
     userStatus += user.getAttackStatus(event) + "\n";
@@ -33,67 +38,79 @@ export async function sendMessage(
   const userStatusContent: string = codeBlock(userStatus);
 
   // クラン紹介
-  const clanTitle: string = bold("凸状況") + "\n"
-  const clanProfile: string = "# " + clan.name + " (" + users.length + "人)\n"
-  const reportRepository = dataSource.getRepository(Report)
+  const clanTitle: string = bold("凸状況") + "\n";
+  const clanProfile: string = "# " + clan.name + " (" + users.length + "人)\n";
+  const reportRepository = dataSource.getRepository(Report);
   const todayReports = await reportRepository.find({
     where: {
       clanId: clan.id,
       eventId: event.id,
-      day: event.getClanBattleDay()
-    }
-  })
-  const latestReport = todayReports.reduce((a, b) => a.UpdatedAt! > b.UpdatedAt! ? a : b)
-  const latestreportTime: string = latestReport.UpdatedAt ?
-    time(latestReport.UpdatedAt) :
-    "-"
+      day: event.getClanBattleDay(),
+    },
+  });
+  const latestReport = todayReports.reduce((a, b) =>
+    a.UpdatedAt! > b.UpdatedAt! ? a : b
+  );
+  const latestreportTime: string = latestReport.UpdatedAt
+    ? time(latestReport.UpdatedAt)
+    : "-";
   const clanStatus: string =
     clanTitle + codeBlock(clanProfile + latestreportTime);
-  
+
   // 凸数
   const attackedCount = todayReports.filter((report) => {
-    return report.isCarryOver == false
-  }).length
+    return report.isCarryOver == false;
+  }).length;
   // TODO 持ち越し凸の数を加える
-  const notAttackCount = (users.length * 3) - attackedCount
+  const notAttackCount = users.length * 3 - attackedCount;
   const attackStatus = codeBlock(
-    "残凸: " + notAttackCount + " 凸 x 持\n" +
-    "済凸: " + attackedCount + " 凸"
-  )
-  
-  // ボス状況
-  const bossRepository = dataSource.getRepository(Boss)
-  const bosses = await bossRepository.find()
-  // TODO ボスHP情報を盛り込む
-  let bossStatus = codeBlock(
-    bosses[0].bossid +
-    " (" +
-    clan.boss1Lap +
-    "周)\n" +
-    "  xxxx / 00000 \n" +
-    bosses[1].bossid +
-    " (" +
-    clan.boss2Lap +
-    "周)\n" +
-    "  xxxx / 00000 \n" +
-    bosses[2].bossid +
-    " (" +
-    clan.boss3Lap +
-    "周)\n" +
-    "  xxxx / 00000 \n" +
-    bosses[3].bossid +
-    " (" +
-    clan.boss4Lap +
-    "周)\n" +
-    "  xxxx / 00000 \n" +
-    bosses[4].bossid +
-    " (" +
-    clan.boss5Lap +
-    "周)\n" +
-    "  xxxx / 00000 \n"
+    "残凸: " + notAttackCount + " 凸 x 持\n" + "済凸: " + attackedCount + " 凸"
   );
 
-  const content: string = userStatusContent + clanStatus + attackStatus + bossStatus;
+  // 周回数
+  const lapRepository = dataSource.getRepository(Lap);
+  const lap = await lapRepository.findOneBy({
+    clanId: clan.id,
+    eventId: event.id,
+  });
+  if (lap == null) {
+    throw new Error("lap is null");
+  }
+
+  // ボス状況
+  const bossRepository = dataSource.getRepository(Boss);
+  const bosses = await bossRepository.find();
+  // TODO ボスHP情報を盛り込む
+  const bossStatus = codeBlock(
+    bosses[0].bossid +
+      " (" +
+      lap.boss1Lap +
+      "周)\n" +
+      "  xxxx / 00000 \n" +
+      bosses[1].bossid +
+      " (" +
+      lap.boss2Lap +
+      "周)\n" +
+      "  xxxx / 00000 \n" +
+      bosses[2].bossid +
+      " (" +
+      lap.boss3Lap +
+      "周)\n" +
+      "  xxxx / 00000 \n" +
+      bosses[3].bossid +
+      " (" +
+      lap.boss4Lap +
+      "周)\n" +
+      "  xxxx / 00000 \n" +
+      bosses[4].bossid +
+      " (" +
+      lap.boss5Lap +
+      "周)\n" +
+      "  xxxx / 00000 \n"
+  );
+
+  const content: string =
+    userStatusContent + clanStatus + attackStatus + bossStatus;
   const components = [
     new ActionRowBuilder<ButtonBuilder>().addComponents(
       button_reload_attack_status.data,

--- a/src/migration/1695991736813-addLap.ts
+++ b/src/migration/1695991736813-addLap.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLap1695991736813 implements MigrationInterface {
+    name = 'AddLap1695991736813'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`lap\` (\`id\` int NOT NULL AUTO_INCREMENT, \`clanId\` int NOT NULL, \`eventId\` int NOT NULL, \`boss1Lap\` int NOT NULL DEFAULT '1', \`boss2Lap\` int NOT NULL DEFAULT '1', \`boss3Lap\` int NOT NULL DEFAULT '1', \`boss4Lap\` int NOT NULL DEFAULT '1', \`boss5Lap\` int NOT NULL DEFAULT '1', PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`clan\` DROP COLUMN \`boss1Lap\``);
+        await queryRunner.query(`ALTER TABLE \`clan\` DROP COLUMN \`boss2Lap\``);
+        await queryRunner.query(`ALTER TABLE \`clan\` DROP COLUMN \`boss3Lap\``);
+        await queryRunner.query(`ALTER TABLE \`clan\` DROP COLUMN \`boss4Lap\``);
+        await queryRunner.query(`ALTER TABLE \`clan\` DROP COLUMN \`boss5Lap\``);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`clan\` ADD \`boss5Lap\` int NOT NULL DEFAULT '1'`);
+        await queryRunner.query(`ALTER TABLE \`clan\` ADD \`boss4Lap\` int NOT NULL DEFAULT '1'`);
+        await queryRunner.query(`ALTER TABLE \`clan\` ADD \`boss3Lap\` int NOT NULL DEFAULT '1'`);
+        await queryRunner.query(`ALTER TABLE \`clan\` ADD \`boss2Lap\` int NOT NULL DEFAULT '1'`);
+        await queryRunner.query(`ALTER TABLE \`clan\` ADD \`boss1Lap\` int NOT NULL DEFAULT '1'`);
+        await queryRunner.query(`DROP TABLE \`lap\``);
+    }
+
+}


### PR DESCRIPTION
close #14
close #20

- [x] Clanテーブルから周回数の保持を分離して別テーブルに移行
- [x] typeORMのmigration周りのコマンド整備
- [x] 凸報告で撃破したときに対象ボスの周回数を1周増やすようにする
- [x] 周回数を見せる必要がある箇所に対してlapテーブルから参照するよう修正
- [ ] 凸宣言時に周回数の関係で殴れないボスは凸宣言をさせない
