### PR TITLE
Github ActionsにおけるESLintのCIを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "npm"
+      - name: Install Packages
+        run: npm ci
+      - name: ESLint
+        run: npm run lint:eslint
+#     - name: Test
+#       run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ClanBattleBot
 
+![ci workflow](https://github.com/yuina1056/ClanBattleBot/actions/workflows/ci.yml/badge.svg)
+
 プリンセスコネクト！Re:Diveのクランバトルを管理するためのDiscordBot
 
 ## 機能

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "typeorm:generate": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:generate -d src/datasource.ts",
     "typeorm:up": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run -d src/datasource.ts",
     "typeorm:down": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert -d src/datasource.ts",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "eslint .",
+    "lint:eslint:fix": "npm run lint:eslint --fix"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "deploy-command": "ts-node -r tsconfig-paths/register src/deploy-command.ts",
     "typeorm:generate": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:generate -d src/datasource.ts",
     "typeorm:up": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run -d src/datasource.ts",
-    "typeorm:down": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert -d src/datasource.ts"
+    "typeorm:down": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert -d src/datasource.ts",
+    "lint:eslint": "eslint ."
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
issue #38 の一部

これでCIが回るようになるね！

## やったこと

- package.jsonに`lint:eslint`と`lint:eslint:fix`を追加
  - 命名はeslintやprettierで使われているよくある命名規則
  - 今後、`lint:prettier`や`lint:prettier:fix`のように追加していく
- Github Actionsを追加
  - developブランチへのpushとPRでまわすようにした
  - 名前はCIと一般的なものをつけている
    - 今後増えるようならcheck/test/...のように名前を変えて増やしていけば良いと思う。
- README.mdにCI結果のバッジを追加
  - かっこいいですね

## やってないこと

- ESLintの警告の修正
- ESLint以外のLintの追加
  - prettier checkなど
  - 別PRで追加する予定