### PR TITLE
解凍処理の実装

### DIFF
--- a/src/commands/button/reportDefeat.ts
+++ b/src/commands/button/reportDefeat.ts
@@ -179,13 +179,30 @@ export class ReportDefeat extends Button {
       isCarryOver,
     );
 
-    const declarations =
+    let declarations =
       await new DeclarationRepository().getDeclarationsByClanIdAndBossNoAndIsFinishedAndEventIdToRelationUser(
         clan.id,
         boss.bossNo,
         false,
         event.id,
       );
+
+    if (declarations.length != 0) {
+      const declarationUsers: string[] = declarations.map(
+        (declaration) => declaration.user.discordUserId ?? 0,
+      );
+      await new DeclarationRepository().deleteByIds(
+        declarations.map((declaration) => declaration.id ?? 0),
+      );
+      if (!channel.isTextBased()) {
+        throw new Error("interaction.channel is not TextBasedChannel");
+      }
+      channel.send({
+        content: declarationUsers.map((userId) => "<@" + userId + ">").join(" ") + "解凍！",
+      });
+      declarations = [];
+    }
+
     const deleteMessage = await channel.messages.fetch(interaction.message.id ?? "");
     await deleteMessage.delete();
     await BossChannelMessage.sendMessage(interaction.channel, clan, boss, clanEvent, declarations);

--- a/src/commands/button/reportDefeat.ts
+++ b/src/commands/button/reportDefeat.ts
@@ -198,7 +198,9 @@ export class ReportDefeat extends Button {
         throw new Error("interaction.channel is not TextBasedChannel");
       }
       channel.send({
-        content: declarationUsers.map((userId) => "<@" + userId + ">").join(" ") + "解凍！",
+        content:
+          declarationUsers.map((userId) => "<@" + userId + ">").join(" ") +
+          "解凍！\n（凸宣言が取り消しされました）",
       });
       declarations = [];
     }

--- a/src/repository/declarationRepository.ts
+++ b/src/repository/declarationRepository.ts
@@ -90,6 +90,9 @@ export class DeclarationRepository {
   async deleteById(id: number): Promise<void> {
     await DeclarationRepository.repository.delete(id);
   }
+  async deleteByIds(ids: number[]): Promise<void> {
+    await DeclarationRepository.repository.delete(ids);
+  }
   async deleteByUserIdAndEventIdAndDayAndAttackCount(
     userId: number,
     eventId: number,


### PR DESCRIPTION
#93 の対応。
解凍ボタンを作らず、撃破時に残っている宣言を取り消し扱いすることで解凍の動作を実現する。